### PR TITLE
fix: keep views/dist in place while building (#481)

### DIFF
--- a/run-command.mjs
+++ b/run-command.mjs
@@ -136,14 +136,20 @@ commands: for (let i = 2; i < process.argv.length; i++)
       const distFinal = fileURLToPath(new URL('./views/dist', import.meta.url));
       const dist = fileURLToPath(new URL('./views/dist-new', import.meta.url));
       rmSync(dist, { force: true, recursive: true });
-      rmSync(distFinal, { force: true, recursive: true });
       mkdirSync(dist);
 
       /* The archive directory is excluded from this process, since source
        * rewrites are not intended to be used by any of those files.
        * Assets are compiled separately, before the rest of the files.
        */
-      const ignoredDirectories = ['dist', 'dist-new', 'assets', 'uv', 'scram'];
+      const ignoredDirectories = [
+        'dist',
+        'dist-new',
+        'dist-old',
+        'assets',
+        'uv',
+        'scram',
+      ];
       const ignoredFileTypes = /\.map$/;
 
       const compile = (
@@ -284,8 +290,11 @@ commands: for (let i = 2; i < process.argv.length; i++)
         await compress('./views/dist-new/pages', true);
       }
 
-      rmSync(distFinal, { force: true, recursive: true });
+      const distOld = distFinal + '-old';
+      rmSync(distOld, { force: true, recursive: true });
+      if (existsSync(distFinal)) renameSync(distFinal, distOld);
       renameSync(dist, distFinal);
+      rmSync(distOld, { force: true, recursive: true });
 
       break;
     }


### PR DESCRIPTION
Fixes #481

As discussed on the issue, this is the fix for the gzip gibberish after a restart.

The build was deleting the live `views/dist` folder while it ran, so a server starting during a build picked up the wrong page loader and kept serving it until the next restart. The build now leaves the current folder in place and only swaps in the new one at the end.

Tested with the real build and server: restarting during a build now gives normal pages instead of gibberish, and the build output is unchanged.
